### PR TITLE
fix: add `apk add coreutils bash` because there are not installed in the Alpine Linux.

### DIFF
--- a/examples/codebuild/bin/codebuildsh
+++ b/examples/codebuild/bin/codebuildsh
@@ -139,6 +139,8 @@ env:
 phases:
   build:
     commands:
+    - apk update
+    - apk add coreutils bash --no-cache
     - stdbuf -i 0 -o 0 -e 0 ./build.sh
 EOF
 


### PR DESCRIPTION
I created variant file below and execute it.

`appctl.var`:

```
#!/usr/bin/env variant

tasks:
  apply:
    runner:
      image: "mumoshu/variant-runner-codebuild:canary"
      envfile: "./ci/codebuild.env"
      volumes:
        - $HOME/.aws/credentials:/root/.aws/credentials
    script: |
      echo "Foo bar"
```

```bash
$ ./appctl.var apply
```

Then, an error has occured:

```
INFO[0033] + jq -jr '.events[] | select(true) | .message' log-events.json  stream=stderr
INFO[0033] + sed -n '/Running command/,$p'               stream=stderr
INFO[0033] + sed 1d                                      stream=stderr
INFO[0033] + tac                                         stream=stderr
INFO[0033] + sed -n '/Phase complete: BUILD/,$p'         stream=stderr
INFO[0033] + sed 1d                                      stream=stderr
INFO[0033] + tac                                         stream=stderr
INFO[0033] /codebuild/output/tmp/script.sh: line 4: stdbuf: not found  stream=stdout
INFO[0033]                                               stream=stdout
INFO[0033] [Container] 2018/08/29 08:41:22 Command did not exit successfully stdbuf -i 0 -o 0 -e 0 ./build.sh exit status 127  stream=stdout
/codebuild/output/tmp/script.sh: line 4: stdbuf: not found
```

So I think it have to install coreutils package which include stdbuf command (cf. https://pkgs.alpinelinux.org/contents?file=stdbuf&path=&name=coreutils&branch=v3.8&repo=main&arch=x86_64).
Bash is used in `./build.sh` ( https://github.com/mumoshu/variant/blob/master/examples/codebuild/bin/codebuildsh#L146 ) but neither is installed on Alpine Linux.