### PR TITLE
support runner.entrypoint parameter

### DIFF
--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -165,9 +165,11 @@ tar zxvf %s.tgz 1>&2
 		if c.Envfile != "" {
 			dockerArgs = append(dockerArgs, "--env-file", c.Envfile)
 		}
+		if c.Entrypoint != "" {
+			dockerArgs = append(dockerArgs, "--entrypoint", c.Entrypoint)
+		}
 		var args []string
 		args = append(args, dockerArgs...)
-		args = append(args, "--entrypoint", c.Entrypoint)
 		args = append(args, c.Image)
 		args = append(args, cmd)
 		args = append(args, cmdArgs...)

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -62,6 +62,9 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 				Args:      args,
 				Artifacts: artifacts,
 			}
+			if entrypoint, ok := runner["entrypoint"].(string); ok {
+				runConf.Entrypoint = entrypoint
+			}
 			if command, ok := runner["command"].(string); ok {
 				runConf.Command = command
 			}
@@ -116,12 +119,13 @@ type Artifact struct {
 }
 
 type runnerConfig struct {
-	Image     string
-	Command   string
-	Artifacts []Artifact
-	Args      []string
-	Envfile   string
-	Volumes   []string
+	Image      string
+	Command    string
+	Entrypoint string
+	Artifacts  []Artifact
+	Args       []string
+	Envfile    string
+	Volumes    []string
 }
 
 func (c runnerConfig) commandNameAndArgsToRunScript(script string, context step.ExecutionContext) (string, []string) {
@@ -163,9 +167,11 @@ tar zxvf %s.tgz 1>&2
 		}
 		var args []string
 		args = append(args, dockerArgs...)
+		args = append(args, "--entrypoint", c.Entrypoint)
 		args = append(args, c.Image)
 		args = append(args, cmd)
 		args = append(args, cmdArgs...)
+
 		return "docker", append([]string{"run", "--rm", "-i"}, args...)
 	} else {
 		return cmd, cmdArgs

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -63,7 +63,7 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 				Artifacts: artifacts,
 			}
 			if entrypoint, ok := runner["entrypoint"].(string); ok {
-				runConf.Entrypoint = entrypoint
+				runConf.Entrypoint = &entrypoint
 			}
 			if command, ok := runner["command"].(string); ok {
 				runConf.Command = command
@@ -121,7 +121,7 @@ type Artifact struct {
 type runnerConfig struct {
 	Image      string
 	Command    string
-	Entrypoint string
+	Entrypoint *string
 	Artifacts  []Artifact
 	Args       []string
 	Envfile    string
@@ -165,8 +165,8 @@ tar zxvf %s.tgz 1>&2
 		if c.Envfile != "" {
 			dockerArgs = append(dockerArgs, "--env-file", c.Envfile)
 		}
-		if c.Entrypoint != "" {
-			dockerArgs = append(dockerArgs, "--entrypoint", c.Entrypoint)
+		if c.Entrypoint != nil {
+			dockerArgs = append(dockerArgs, "--entrypoint", *c.Entrypoint)
 		}
 		var args []string
 		args = append(args, dockerArgs...)


### PR DESCRIPTION
Added parameters for overwriting docker `--entrypoint` option.

```
runner:
  image: mesosphere/aws-cli:1.14.5
  command: /bin/sh
  args: [-c]
script: echo 111;
```

```
DEBU[0000] script step started                           cmd="[docker run --rm -i --entrypoint  mesosphere/aws-cli:1.14.5 /bin/sh -c echo 111;]"
INFO[0000] 111    
```
