### PR TITLE
fix c.Entrypoint type error

### DIFF
--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -181,7 +181,6 @@ tar zxvf %s.tgz 1>&2
 		}
 		var args []string
 		args = append(args, dockerArgs...)
-		args = append(args, "--entrypoint", *c.Entrypoint)
 		args = append(args, c.Image)
 		args = append(args, cmd)
 		args = append(args, cmdArgs...)

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -181,7 +181,7 @@ tar zxvf %s.tgz 1>&2
 		}
 		var args []string
 		args = append(args, dockerArgs...)
-		args = append(args, "--entrypoint", c.Entrypoint)
+		args = append(args, "--entrypoint", *c.Entrypoint)
 		args = append(args, c.Image)
 		args = append(args, cmd)
 		args = append(args, cmdArgs...)


### PR DESCRIPTION
An error below has occured when running `make build` or `go get -u github.com/mumoshu/variant`.

```
 %  make build
test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
mkdir -p dist/
# go tool nm dist/v/var | grep VERSION
#  8b0780 D _/Users/me/path/to/variant/cli/version.VERSION
#  6dff9c R _/Users/me/path/to/variant/cli/version.VERSION.str
go build -ldflags "-X '_/Users/hashimoto-takuma/go/src/github.com/mumoshu/variant/cli/version.VERSION='" -o dist//var .
# github.com/mumoshu/variant/pkg/steps
pkg/steps/script_step.go:184:23: cannot use c.Entrypoint (type *string) as type string in append
make: *** [dist] Error 2

 %  go get -u github.com/mumoshu/variant
# github.com/mumoshu/variant/pkg/steps
go/src/github.com/mumoshu/variant/pkg/steps/script_step.go:184:23: cannot use c.Entrypoint (type *string) as type string in append
```

- ref. 104a93516bd0ccb6065346473091906db5d4c5db