### PR TITLE
support runner env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,8 @@ smoke21: build
 	cd examples/codebuild; make build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./codebuild-s3 test --s3bucket $(VARIANT_ARTIFACTS_S3_BUCKET) --logtostderr > file.out && cat file.out | tee /dev/stderr | (grep "unit=TESTDATA" file.out) && echo smoke21 passed.
 
+smoke22: build
+	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./containerized-task-autoenv test --logtostderr && echo smoke22 passed.
+
 smoke-tests:
-	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21}
+	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22}

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -71,15 +71,14 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 			if envfile, ok := runner["envfile"].(string); ok {
 				runConf.Envfile = envfile
 			}
-			if environments, ok := runner["env"].(map[interface]interface{}); ok {
+			if environments, ok := runner["env"].(map[interface{}]interface{}); ok {
 				env := make(map[string]string, len(environments))
 				for k, v := range environments {
 					env[k.(string)] = v.(string)
 				}
 				runConf.Env = env
-			} else if autoenv, ok := def.Get("autoenv").(bool); ok && autoenv {
-				runConf.Env = make(map[string]string, len(environments))
 			}
+
 			if volumes, ok := runner["volumes"].([]interface{}); ok {
 				vols := make([]string, len(volumes))
 				for i, v := range volumes {
@@ -173,6 +172,9 @@ tar zxvf %s.tgz 1>&2
 			autoEnv, err := context.GenerateAutoenv()
 			if err != nil {
 				log.Errorf("script step failed to generate autoenv with docker run: %v", err)
+			}
+			if c.Env == nil {
+				c.Env = make(map[string]string, len(autoEnv))
 			}
 			for k, v := range autoEnv {
 				c.Env[k] = v

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -82,7 +82,7 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 			if volumes, ok := runner["volumes"].([]interface{}); ok {
 				vols := make([]string, len(volumes))
 				for i, v := range volumes {
-					vols[i] = os.ExpandEnv(v.(string))
+					vols[i] = v.(string)
 				}
 				runConf.Volumes = vols
 			}
@@ -183,13 +183,13 @@ tar zxvf %s.tgz 1>&2
 
 		dockerArgs := []string{}
 		for _, v := range c.Volumes {
-			dockerArgs = append(dockerArgs, "-v", v)
+			dockerArgs = append(dockerArgs, "-v", os.ExpandEnv(v))
 		}
 		for k, v := range c.Env {
-			dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", k, v))
+			dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", k, os.ExpandEnv(v)))
 		}
 		if c.Envfile != "" {
-			dockerArgs = append(dockerArgs, "--env-file", c.Envfile)
+			dockerArgs = append(dockerArgs, "--env-file", os.ExpandEnv(c.Envfile))
 		}
 		if c.Entrypoint != nil {
 			dockerArgs = append(dockerArgs, "--entrypoint", *c.Entrypoint)

--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -71,6 +71,13 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 			if envfile, ok := runner["envfile"].(string); ok {
 				runConf.Envfile = envfile
 			}
+			if environments, ok := runner["env"].(map[interface]interface{}); ok {
+				env := make(map[string]string, len(environments))
+				for k, v := range environments {
+					env[k.(string)] = v.(string)
+				}
+				runConf.Env = env
+			}
 			if volumes, ok := runner["volumes"].([]interface{}); ok {
 				vols := make([]string, len(volumes))
 				for i, v := range volumes {
@@ -125,6 +132,7 @@ type runnerConfig struct {
 	Artifacts  []Artifact
 	Args       []string
 	Envfile    string
+	Env        map[string]string
 	Volumes    []string
 }
 
@@ -161,6 +169,9 @@ tar zxvf %s.tgz 1>&2
 		dockerArgs := []string{}
 		for _, v := range c.Volumes {
 			dockerArgs = append(dockerArgs, "-v", v)
+		}
+		for k, v := range c.Env {
+			dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", k, v))
 		}
 		if c.Envfile != "" {
 			dockerArgs = append(dockerArgs, "--env-file", c.Envfile)

--- a/test/integration/containerized-task-autoenv
+++ b/test/integration/containerized-task-autoenv
@@ -1,0 +1,41 @@
+#!/usr/bin/env var
+
+tasks:
+  test:
+    steps:
+    - task: runner-env
+    - task: runner-autoenv
+    - task: runner-env-and-autoenv
+  runner-env:
+    runner:
+      image: "alpine:3.7"
+      command: sh
+      args: [-c]
+      env:
+        FOO: foo
+    script: |
+      env | grep "FOO=foo"
+  runner-autoenv:
+    inputs:
+    - name: foo
+      default: "foo"
+    autoenv: true
+    runner:
+      image: "alpine:3.7"
+      command: sh
+      args: [-c]
+    script: |
+      env |  grep "FOO=foo"
+  runner-env-and-autoenv:
+    inputs:
+    - name: foo
+      default: "foo"
+    autoenv: true
+    runner:
+      image: "alpine:3.7"
+      command: sh
+      args: [-c]
+      env:
+        FOOFOO=${FOO}
+    script: |
+      env |  grep "FOOFOO=foo"


### PR DESCRIPTION
support `runner.env`option.

```
  runner-env:
    runner:
      image: "alpine:3.7"
      command: sh
      args: [-c]
      env:
        FOO: foo
    script: |
      env | grep "FOO=foo"
```

and, We have made it possible to expand environment variables and `autoenv` parameters with some runner options.