### PR TITLE
fixes parameters are not set in multistage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,8 @@ smoke21: build
 	cd examples/codebuild; make build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./codebuild-s3 test --s3bucket $(VARIANT_ARTIFACTS_S3_BUCKET) --logtostderr > file.out && cat file.out | tee /dev/stderr | (grep "unit=TESTDATA" file.out) && echo smoke21 passed.
 
+smoke22: build
+	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./multistage-task-parameters test --logtostderr | grep foo && echo smoke22 passed.
+
 smoke-tests:
-	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21}
+	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22}

--- a/pkg/application.go
+++ b/pkg/application.go
@@ -380,6 +380,8 @@ func (p Application) DirectInputValuesForTaskKey(taskName TaskName, args []strin
 						return nil, errors.Annotatef(err, "Missing value for input `%s`. Please provide a command line option or a positional argument or a task for it`", input.ShortName())
 					}
 					maputil.SetValueAtPath(p.CachedTaskOutputs, pathComponents, tmplOrStaticVal)
+				} else {
+					tmplOrStaticVal = output
 				}
 				if err != nil {
 					return nil, errors.Trace(err)

--- a/test/integration/multistage-task-parameters
+++ b/test/integration/multistage-task-parameters
@@ -1,0 +1,21 @@
+#!/usr/bin/env var
+
+tasks:
+  param1:
+    script: |
+      echo foo
+
+  param2:
+    options:
+    - name: param1
+      required: true
+    script: |
+      echo {{ get "param1" }}
+
+  test:
+    options:
+    - name: param2
+      required: true
+    script: |
+      echo {{ get "param2" }}
+


### PR DESCRIPTION
fixes parameters are not set in multistage.

```
tasks:
  param1:
    script: |
      echo foo

  param2:
    options:
    - name: param1
      required: true
    script: |
      echo {{ get "param1" }}

  test:
    options:
    - name: param2
      required: true
    script: |
      echo {{ get "param2" }}
```

We have made it possible to call tasks in multistage like `test -> param2 -> param1`.