### PR TITLE
fixes support interger and bool parameter in autoenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,8 @@ smoke21: build
 	cd examples/codebuild; make build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./codebuild-s3 test --s3bucket $(VARIANT_ARTIFACTS_S3_BUCKET) --logtostderr > file.out && cat file.out | tee /dev/stderr | (grep "unit=TESTDATA" file.out) && echo smoke21 passed.
 
+smoke22: build
+	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./params-type-autoenv test --logtostderr && echo smoke22 passed.
+
 smoke-tests:
-	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21}
+	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22}

--- a/pkg/task_runner.go
+++ b/pkg/task_runner.go
@@ -77,6 +77,10 @@ func (t TaskRunner) GenerateAutoenvRecursively(path string, env map[string]inter
 				result[toEnvName(fmt.Sprintf("%s%s", path, k))] = stringV
 			} else if v == nil {
 				result[toEnvName(fmt.Sprintf("%s%s", path, k))] = ""
+			} else if fmt.Sprintf("%T", v) == "bool" {
+				result[toEnvName(fmt.Sprintf("%s%s", path, k))] = fmt.Sprintf("%t", v)
+			} else if fmt.Sprintf("%T", v) == "int" {
+				result[toEnvName(fmt.Sprintf("%s%s", path, k))] = fmt.Sprintf("%d", v)
 			} else {
 				return nil, errors.Errorf("The value for the key %s was neither a `map[string]interface{}` nor a `string`: %v(%#v)", k, v, v)
 			}

--- a/test/integration/params-type-autoenv
+++ b/test/integration/params-type-autoenv
@@ -1,0 +1,42 @@
+#!/usr/bin/env var
+
+tasks:
+  test:
+    steps:
+    - task: string-env
+    - task: integer-env
+    - task: bool-true-env
+    - task: bool-false-env
+  string-env:
+    options:
+    - name: foo
+      type: string
+      default: foo
+    autoenv: true
+    script: |
+      env | grep "FOO=foo"
+  integer-env:
+    options:
+    - name: foo
+      type: integer
+      default: 1
+    autoenv: true
+    script: |
+      env | grep "FOO=1"
+  bool-true-env:
+    options:
+    - name: foo
+      type: boolean
+      default: true
+    autoenv: true
+    script: |
+      env | grep "FOO=true"
+  bool-false-env:
+    options:
+    - name: foo
+      type: boolean
+      default: false
+    autoenv: true
+    script: |
+      env | grep "FOO=false"
+


### PR DESCRIPTION
When `autoenv` is set to `true` with the parameter of `integer`, `autoenv` becomes invalid.

```
  integer-env:
    options:
    - name: foo
      type: integer
      default: 1
    autoenv: true
    script: |
      env // FOO is not found
```

So we changed it to work according to the type we support.
https://github.com/mumoshu/variant/blob/ef7e10bbe31e344b7156acd4693417d97e52f18f/pkg/application.go#L362