### PR TITLE
support runner.workdir option

### DIFF
--- a/pkg/steps/script_step.go
+++ b/pkg/steps/script_step.go
@@ -78,6 +78,9 @@ func (l ScriptStepLoader) LoadStep(def step.StepDef, context step.LoadingContext
 				}
 				runConf.Volumes = vols
 			}
+			if workdir, ok := runner["workdir"].(string); ok {
+				runConf.Workdir = workdir
+			}
 		} else {
 			log.Debugf("runner wasn't expected type of map: %+v", runner)
 		}
@@ -126,6 +129,7 @@ type runnerConfig struct {
 	Args       []string
 	Envfile    string
 	Volumes    []string
+	Workdir	   string
 }
 
 func (c runnerConfig) commandNameAndArgsToRunScript(script string, context step.ExecutionContext) (string, []string) {
@@ -178,6 +182,9 @@ tar zxvf %s.tgz 1>&2
 		}
 		if c.Entrypoint != nil {
 			dockerArgs = append(dockerArgs, "--entrypoint", *c.Entrypoint)
+		}
+		if c.Workdir != "" {
+			dockerArgs = append(dockerArgs, "--workdir", c.Workdir)
 		}
 		var args []string
 		args = append(args, dockerArgs...)


### PR DESCRIPTION
We have to do `cd /[mount-dir]` with Docke Image which does not specify `WORKDIR`.
Since this is troublesome I have support `runner.workdir`.

```
    runner:
      image: alpine
      command: sh
      args: [-c]
      volumes:
      - $PWD:/alpine
      workdir: /alpine
    script: |
      pwd # -> /alpine
```
