### PR TITLE
Change the default shell from 'sh' to 'bash'

### DIFF
--- a/pkg/step_script.go
+++ b/pkg/step_script.go
@@ -154,7 +154,7 @@ func (c runnerConfig) commandNameAndArgsToRunScript(script string, context Execu
 	if c.Command != "" {
 		cmd = c.Command
 	} else if c.Image == "" {
-		cmd = "sh"
+		cmd = "bash"
 	}
 
 	for _, a := range c.Artifacts {


### PR DESCRIPTION
Change the default shell from 'sh' to 'bash', because 'sh' is inconclusive between distributions.

_Example_

ubuntu

```
$ ls -al /bin/sh
lrwxrwxrwx. 1 root root 4 Feb 17  2016 /bin/sh -> dash
```

centos
```
$ ls -al /bin/sh
lrwxrwxrwx 1 root root 4 Dec  5 01:36 /bin/sh -> bash
```