### PR TITLE
change the resolve order of envfile

### DIFF
--- a/pkg/cli/env/env.go
+++ b/pkg/cli/env/env.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -32,7 +33,15 @@ func SetAppName(name string) {
 
 func GetPath() string { return e.GetPath() }
 func (e *EnvFile) GetPath() string {
-	return fmt.Sprintf(".%senv", e.appName)
+	f := fmt.Sprintf(".%senv", e.appName)
+	if _, err := os.Stat(f); !os.IsNotExist(err) {
+		return f
+	}
+	f = ".variantenv"
+	if _, err := os.Stat(f); !os.IsNotExist(err) {
+		return f
+	}
+	return ".varenv"
 }
 
 func Set(env string) error { return e.Set(env) }


### PR DESCRIPTION
changed the resolve order of envfile.

1. `.[command]env`
2. `.variantenv`
3. `.varenv`

We have use cases of multiple variant commands.

```
.
├── .command1env
├── .command2env
├── .command3env
├── command1
├── command2
└── command3
```

However, it is very difficult to manage multiple envfiles.
So we made it read common `.variantenv` and `.varenv`.