### PR TITLE
fixes an issue where merging `map[interface{}]interface{}` caused an error

### DIFF
--- a/pkg/util/maputil/maputil.go
+++ b/pkg/util/maputil/maputil.go
@@ -141,10 +141,18 @@ func DeepMerge(dest map[string]interface{}, src map[string]interface{}) {
 	for k, v := range src {
 		if m, isMap := v.(map[string]interface{}); isMap {
 			if _, destIsMap := dest[k].(map[string]interface{}); !destIsMap {
-				if dest[k] != nil {
-					log.Panicf("maputil manics! unexpected type of value in map: dest=%v, k=%v, dest[k]=%v", dest, k, dest[k])
+				if d, destIsInterfaceMap := dest[k].(map[interface{}]interface{}); !destIsInterfaceMap {
+					if dest[k] != nil {
+						log.Panicf("maputil panics! unexpected type of value in map: dest=%v, k=%v, dest[k]=%v", dest, k, dest[k])
+					}
+					dest[k] = map[string]interface{}{}
+				} else {
+					ds, err := CastKeysToStrings(d)
+					if err != nil {
+						log.Panicf("maputil panics! unexpected state of d: %v", d)
+					}
+					dest[k] = ds
 				}
-				dest[k] = map[string]interface{}{}
 			}
 			d, ok := dest[k].(map[string]interface{})
 


### PR DESCRIPTION
If the `type: Object` parameter value is `merge`, map will be evaluated as `map[interface{}]interface{}` and an error will occur.

```yaml
#!/usr/bin/env variant

tasks:
  foo:
    parameters:
    - name: obj
      type: object
    script: |
      cat <<EOS
      {{ merge (readFile (get "cmd") | fromYaml) (get "obj") | toYaml }}
      EOS

  bar:
    steps:
    - task: foo
      arguments:
        obj: |
          {
            "tasks": {
              "bar": 1
            }
          }
```

```bash
$  ./cmd bar
maputil manics! unexpected type of value in map: dest=map[tasks:map[bar:map[steps:[map[task:foo arguments:map[obj:{
  "tasks": {
    "bar": 1
  }
}]]]] foo:map[parameters:[map[name:obj type:object]] script:cat <<EOS
{{ merge (readFile (get "cmd") | fromYaml) (get "obj") | toYaml }}
EOS
]]], k=tasks, dest[k]=map[foo:map[parameters:[map[name:obj type:object]] script:cat <<EOS
{{ merge (readFile (get "cmd") | fromYaml) (get "obj") | toYaml }}
EOS
] bar:map[steps:[map[task:foo arguments:map[obj:{
  "tasks": {
    "bar": 1
  }
}]]]]]
panic: (*logrus.Entry) (0x17dd820,0xc4202d6a80) [recovered]
	panic: (*logrus.Entry) (0x17dd820,0xc4202d6a80)

goroutine 1 [running]:
text/template.errRecover(0xc4202523e0)
	/usr/local/go/src/text/template/exec.go:143 +0x1ba
panic(0x17dd820, 0xc4202d6a80)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.Entry.log(0xc4200ba000, 0xc4202d8270, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/entry.go:227 +0x301
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.(*Entry).Log(0xc4200bb1a0, 0xc400000000, 0xc420251668, 0x1, 0x1)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/entry.go:256 +0xb7
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.(*Entry).Logf(0xc4200bb1a0, 0xc400000000, 0x18152a3, 0x4a, 0xc420251800, 0x3, 0x3)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/entry.go:301 +0xdf
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.(*Logger).Logf(0xc4200ba000, 0x0, 0x18152a3, 0x4a, 0xc420251800, 0x3, 0x3)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/logger.go:137 +0x94
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.(*Logger).Panicf(0xc4200ba000, 0x18152a3, 0x4a, 0xc420251800, 0x3, 0x3)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/logger.go:178 +0x65
github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus.Panicf(0x18152a3, 0x4a, 0xc420251800, 0x3, 0x3)
	/go/src/github.com/mumoshu/variant/vendor/github.com/sirupsen/logrus/exported.go:168 +0x5f
github.com/mumoshu/variant/pkg/util/maputil.DeepMerge(0xc4202d8c30, 0xc42029fb90)
	/go/src/github.com/mumoshu/variant/pkg/util/maputil/maputil.go:145 +0x4cd
github.com/mumoshu/variant/pkg._merge(0xc4202d8c30, 0xc4202bb2d0, 0x1, 0x1, 0x2, 0x10, 0x1006b1d)
	/go/src/github.com/mumoshu/variant/pkg/task_template_funcs.go:92 +0x7f
github.com/mumoshu/variant/pkg._merge(0xc4202d8c30, 0xc4202bb2c0, 0x2, 0x2, 0xc4202c2e30, 0x1, 0x1)
	/go/src/github.com/mumoshu/variant/pkg/task_template_funcs.go:94 +0xc2
github.com/mumoshu/variant/pkg.merge(0x17155a0, 0xc4202d8960, 0xc4202c2e30, 0x1, 0x1, 0x0, 0x0, 0x0)
	/go/src/github.com/mumoshu/variant/pkg/task_template_funcs.go:69 +0x112
reflect.Value.call(0x17108c0, 0x181efd8, 0x13, 0x17ed062, 0x4, 0xc4202d86f0, 0x2, 0x2, 0x17e7340, 0x1726501, ...)
	/usr/local/go/src/reflect/value.go:447 +0x969
reflect.Value.Call(0x17108c0, 0x181efd8, 0x13, 0xc4202d86f0, 0x2, 0x2, 0x18d4580, 0xc4200b3630, 0x17155a0)
	/usr/local/go/src/reflect/value.go:308 +0xa4
text/template.(*state).evalCall(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0x17108c0, 0x181efd8, 0x13, 0x18d4380, 0xc4202d8420, 0xc4200985ad, ...)
	/usr/local/go/src/text/template/exec.go:667 +0x4f1
text/template.(*state).evalFunction(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0xc4202d8450, 0x18d4380, 0xc4202d8420, 0xc4200a7bc0, 0x3, 0x4, ...)
	/usr/local/go/src/text/template/exec.go:535 +0x176
text/template.(*state).evalCommand(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0xc4202d8420, 0x0, 0x0, 0x0, 0xd0, 0xd0, ...)
	/usr/local/go/src/text/template/exec.go:432 +0x516
text/template.(*state).evalPipeline(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0xc4200b3540, 0x0, 0x0, 0x30)
	/usr/local/go/src/text/template/exec.go:405 +0x10f
text/template.(*state).walk(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0x18d42c0, 0xc4202d8660)
	/usr/local/go/src/text/template/exec.go:231 +0x4a5
text/template.(*state).walk(0xc420252360, 0x17155a0, 0xc42029fa40, 0x15, 0x18d44c0, 0xc4202d83c0)
	/usr/local/go/src/text/template/exec.go:239 +0x11d
text/template.(*Template).execute(0xc4200a7ac0, 0x18cacc0, 0xc4202b49a0, 0x17155a0, 0xc42029fa40, 0x0, 0x0)
	/usr/local/go/src/text/template/exec.go:194 +0x1e6
text/template.(*Template).Execute(0xc4200a7ac0, 0x18cacc0, 0xc4202b49a0, 0x17155a0, 0xc42029fa40, 0x0, 0x27)
	/usr/local/go/src/text/template/exec.go:177 +0x53
github.com/mumoshu/variant/pkg.(*TaskTemplate).Render(0xc4202c28c0, 0xc4200985a0, 0x51, 0x17ef573, 0x6, 0xc420252678, 0xc4202526a8, 0xc4202526a8, 0x0)
	/go/src/github.com/mumoshu/variant/pkg/task_template.go:81 +0x38a
github.com/mumoshu/variant/pkg.ExecutionContext.Render(0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, 0xc42029ec60, 0x0, 0x0, 0x0, 0x17ed792, 0x4, ...)
	/go/src/github.com/mumoshu/variant/pkg/step_execution_context.go:42 +0x66
github.com/mumoshu/variant/pkg.ScriptStep.Run(0x17ef573, 0x6, 0xc4200985a0, 0x51, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/mumoshu/variant/pkg/step_script.go:246 +0x3bc
github.com/mumoshu/variant/pkg.(*TaskRunner).Run(0xc4202bae20, 0xc420253f20, 0x0, 0xc420254178, 0x1, 0x1, 0x0, 0x0, 0x17ed792, 0x4)
	/go/src/github.com/mumoshu/variant/pkg/task_runner.go:110 +0x5c8
github.com/mumoshu/variant/pkg.Application.RunTask(0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, 0xc42029ec60, 0x0, 0x0, 0x0, 0x17ed792, 0x4, ...)
	/go/src/github.com/mumoshu/variant/pkg/application.go:163 +0xe48
github.com/mumoshu/variant/pkg.Application.RunTaskForKeyString(0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, 0xc42029ec60, 0x0, 0x0, 0x0, 0x17ed792, 0x4, ...)
	/go/src/github.com/mumoshu/variant/pkg/application.go:70 +0x215
github.com/mumoshu/variant/pkg.ExecutionContext.RunAnotherTask(0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, 0xc42029ec60, 0x0, 0x0, 0x0, 0x17ed792, 0x4, ...)
	/go/src/github.com/mumoshu/variant/pkg/step_execution_context.go:58 +0x110
github.com/mumoshu/variant/pkg.TaskStep.Run(0xc42028ca78, 0x6, 0xc42028c990, 0x3, 0xc42029e9c0, 0x0, 0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, ...)
	/go/src/github.com/mumoshu/variant/pkg/step_task.go:41 +0xf2
github.com/mumoshu/variant/pkg.(*TaskRunner).Run(0xc4202ba960, 0xc4202555b8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x17ed792, 0x4)
	/go/src/github.com/mumoshu/variant/pkg/task_runner.go:110 +0x5c8
github.com/mumoshu/variant/pkg.Application.RunTask(0x7ffeefbffa1a, 0x4, 0x7ffeefbffa18, 0x6, 0xc42029ec60, 0x0, 0x0, 0x0, 0x17ed792, 0x4, ...)
	/go/src/github.com/mumoshu/variant/pkg/application.go:163 +0xe48
github.com/mumoshu/variant/pkg.(*CobraAdapter).GenerateCommand.func1(0xc420292f00, 0x1cd1a60, 0x0, 0x0)
	/go/src/github.com/mumoshu/variant/pkg/cobra.go:54 +0x16b
github.com/mumoshu/variant/vendor/github.com/spf13/cobra.(*Command).execute(0xc420292f00, 0x1cd1a60, 0x0, 0x0, 0xc420292f00, 0x1cd1a60)
	/go/src/github.com/mumoshu/variant/vendor/github.com/spf13/cobra/command.go:766 +0x2c1
github.com/mumoshu/variant/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420292a00, 0x4, 0xc42028cc24, 0xc4200d2e00)
	/go/src/github.com/mumoshu/variant/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/mumoshu/variant/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420292a00, 0x4, 0x4)
	/go/src/github.com/mumoshu/variant/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/mumoshu/variant/pkg/run.RunTaskDef(0x7ffeefbffa18, 0x6, 0xc4200ced00, 0xc42009e0b0, 0x1, 0x1)
	/go/src/github.com/mumoshu/variant/pkg/run/run.go:240 +0xade
github.com/mumoshu/variant/pkg/run.Dev()
	/go/src/github.com/mumoshu/variant/pkg/run/run.go:95 +0x314
main.main()
	/go/src/github.com/mumoshu/variant/main.go:8 +0x20
```

