### PR TITLE
feat: Add custom log colors

### DIFF
--- a/pkg/application.go
+++ b/pkg/application.go
@@ -66,7 +66,7 @@ func (p Application) UpdateLoggingConfiguration() error {
 		p.Log.SetFormatter(&variantTextFormatter{
 			colorize: colorize,
 		    colors: map[logrus.Level] string {
-		        logrus.PanicLevel: p.Viper.Get("log_color_panic").(string),
+				logrus.PanicLevel: p.Viper.Get("log_color_panic").(string),
 				logrus.FatalLevel: p.Viper.Get("log_color_fatal").(string),
 				logrus.ErrorLevel: p.Viper.Get("log_color_error").(string),
 				logrus.WarnLevel: p.Viper.Get("log_color_warn").(string),

--- a/pkg/application.go
+++ b/pkg/application.go
@@ -65,12 +65,12 @@ func (p Application) UpdateLoggingConfiguration() error {
 
 		p.Log.SetFormatter(&variantTextFormatter{
 			colorize: colorize,
-		    colors: map[logrus.Level] string {
+			colors: map[logrus.Level]string{
 				logrus.PanicLevel: p.Viper.Get("log_color_panic").(string),
 				logrus.FatalLevel: p.Viper.Get("log_color_fatal").(string),
 				logrus.ErrorLevel: p.Viper.Get("log_color_error").(string),
-				logrus.WarnLevel: p.Viper.Get("log_color_warn").(string),
-				logrus.InfoLevel: p.Viper.Get("log_color_info").(string),
+				logrus.WarnLevel:  p.Viper.Get("log_color_warn").(string),
+				logrus.InfoLevel:  p.Viper.Get("log_color_info").(string),
 				logrus.DebugLevel: p.Viper.Get("log_color_debug").(string),
 				logrus.TraceLevel: p.Viper.Get("log_color_trace").(string),
 			},

--- a/pkg/application.go
+++ b/pkg/application.go
@@ -62,7 +62,19 @@ func (p Application) UpdateLoggingConfiguration() error {
 			Disable: !p.Colorize,
 			Reset:   true,
 		}
-		p.Log.SetFormatter(&variantTextFormatter{colorize: colorize})
+
+		p.Log.SetFormatter(&variantTextFormatter{
+			colorize: colorize,
+		    colors: map[logrus.Level] string {
+		        logrus.PanicLevel: p.Viper.Get("log_color_panic").(string),
+				logrus.FatalLevel: p.Viper.Get("log_color_fatal").(string),
+				logrus.ErrorLevel: p.Viper.Get("log_color_error").(string),
+				logrus.WarnLevel: p.Viper.Get("log_color_warn").(string),
+				logrus.InfoLevel: p.Viper.Get("log_color_info").(string),
+				logrus.DebugLevel: p.Viper.Get("log_color_debug").(string),
+				logrus.TraceLevel: p.Viper.Get("log_color_trace").(string),
+			},
+		})
 	} else if p.Output == "message" {
 		p.Log.SetFormatter(&MessageOnlyFormatter{})
 	} else {

--- a/pkg/variant.go
+++ b/pkg/variant.go
@@ -106,14 +106,17 @@ func Init(rootTaskConfig *TaskDef, opts ...Opts) (*CobraApp, error) {
 	rootCmd.PersistentFlags().StringVarP(&(p.ConfigFile), "config-file", "c", "", "Path to config file")
 	rootCmd.PersistentFlags().BoolVar(&(p.LogToStderr), "logtostderr", true, "write log messages to stderr")
 
+	// Set default colors for the logs.
+	v.SetDefault("log_color_panic", "red")
+	v.SetDefault("log_color_fatal", "red")
+	v.SetDefault("log_color_error", "red")
+	v.SetDefault("log_color_warn", "red")
+	v.SetDefault("log_color_info", "cyan")
+	v.SetDefault("log_color_debug", "dark_gray")
+	v.SetDefault("log_color_trace", "dark_gray")
+
 	// see `func ExecuteC` in https://github.com/spf13/cobra/blob/master/command.go#L671-L677 for usage of ParseFlags()
 	rootCmd.ParseFlags(o.Args)
-
-	// Workaround: We want to set log level via command-line option before the rootCmd is run
-	err = p.UpdateLoggingConfiguration()
-	if err != nil {
-		return nil, err
-	}
 
 	// Deferred to respect output format specified via the --output flag
 	//if !varfileExists {
@@ -175,6 +178,12 @@ func Init(rootTaskConfig *TaskDef, opts ...Opts) (*CobraApp, error) {
 	//Substitute the . and - to _,
 	replacer := strings.NewReplacer(".", "_", "-", "_")
 	v.SetEnvKeyReplacer(replacer)
+
+	// Workaround: We want to set log level via command-line option before the rootCmd is run
+	err = p.UpdateLoggingConfiguration()
+	if err != nil {
+		return nil, err
+	}
 
 	//	var rootCmd = &cobra.Command{Use: c.Name}
 

--- a/pkg/variant_text_log_formatter.go
+++ b/pkg/variant_text_log_formatter.go
@@ -8,17 +8,11 @@ import (
 
 type variantTextFormatter struct {
 	colorize *colorstring.Colorize
+	colors map[logrus.Level]string
 }
 
 func (f *variantTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	var prefix string
-	if entry.Level < logrus.InfoLevel {
-		prefix = "[red]"
-	} else if entry.Level < logrus.DebugLevel {
-		prefix = "[cyan]"
-	} else {
-		prefix = "[dark_gray]"
-	}
+	var prefix = "[" + f.colors[entry.Level] + "]"
 	app := entry.Data["app"]
 	if app != nil {
 		switch app := app.(type) {

--- a/pkg/variant_text_log_formatter.go
+++ b/pkg/variant_text_log_formatter.go
@@ -8,7 +8,7 @@ import (
 
 type variantTextFormatter struct {
 	colorize *colorstring.Colorize
-	colors map[logrus.Level]string
+	colors   map[logrus.Level]string
 }
 
 func (f *variantTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {


### PR DESCRIPTION
**WHAT:**
Add custom colors for log messages.

**WHY:**
For some cases, we want to allow to set custom colors for every type of log messages (panic, fatal, error, warn, info, debug, trace). For example, many CLI commands output info messages into STDERR which is echoed as "red" from the variant ("warn" level in variant) and we want to be able to set another color for these messages to be able to distinguish them from the actual errors.

---

WIth this PR we'll be able to set custom colors for the log messages through **viper** params (e.g. env var VARIANT_LOG_COLOR_WARN=light_blue, etc).