### PR TITLE
feat: Named step outputs are now parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,12 @@ smoke27: build
 smoke28: build
 	cd $(IT_DIR)/type-object-param && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && var --logtostderr > out && cat out | tee /dev/stderr && echo smoke28 passed.
 
+smoke29: build
+	cd $(IT_DIR)/step-result-as-param && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && var --logtostderr > out && cat out | tee /dev/stderr && echo smoke29 passed.
+
 
 smoke-tests:
 	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27}
 
 smoke-ci:
-	bash -c 'make smoke{1..18} smoke{23,24,25,26,27,28}'
+	bash -c 'make smoke{1..18} smoke{23,24,25,26,27,28,29}'

--- a/pkg/step_execution_context.go
+++ b/pkg/step_execution_context.go
@@ -22,6 +22,12 @@ func NewStepExecutionContext(app Application, taskRunner TaskRunner, taskTemplat
 	}
 }
 
+func (c ExecutionContext) WithAdditionalValues(vs map[string]interface{}) ExecutionContext {
+	ctx := c
+	ctx.taskTemplate = c.taskTemplate.WithAdditionalValues(vs)
+	return ctx
+}
+
 func (c ExecutionContext) GenerateAutoenv() (map[string]string, error) {
 	return c.taskRunner.GenerateAutoenv()
 }

--- a/pkg/task_runner.go
+++ b/pkg/task_runner.go
@@ -113,6 +113,10 @@ func (t *TaskRunner) Run(project *Application, asInput bool, caller ...*Task) (s
 			return lastout.String, errors.Wrap(err, "Task#Run failed while running a script")
 		}
 
+		if s.GetName() != "" {
+			context = context.WithAdditionalValues(map[string]interface{}{s.GetName(): lastout.String})
+		}
+
 		if !s.Silenced() && len(lastout.String) > 0 {
 			var sep string
 			if output.String != "" && !strings.HasSuffix(output.String, "\n") {

--- a/pkg/task_template.go
+++ b/pkg/task_template.go
@@ -84,3 +84,17 @@ func (t *TaskTemplate) Render(expr string, name string) (string, error) {
 
 	return buff.String(), nil
 }
+
+func (t *TaskTemplate) WithAdditionalValues(vs map[string]interface{}) *TaskTemplate {
+	newVals := map[string]interface{}{}
+	for k, v := range t.values {
+		newVals[k] = v
+	}
+	for k, v := range vs {
+		newVals[k] = v
+	}
+
+	newTmpl := *t
+	newTmpl.values = newVals
+	return &newTmpl
+}

--- a/test/integration/step-result-as-param/Variantfile
+++ b/test/integration/step-result-as-param/Variantfile
@@ -1,0 +1,33 @@
+#!/usr/bin/env var
+
+tasks:
+  duplicate:
+    parameters:
+    - name: input
+      type: string
+      default: ""
+    script: |
+      echo "{{.input}}_{{.input}}"
+  test:
+    parameters:
+    - name: input
+      type: string
+    - name: expected
+      type: string
+    steps:
+    - name: res
+      task: duplicate
+      arguments:
+        input: "{{.input}}"
+    - name: actual
+      script: |
+        echo "Double {{.input}} will be: {{.res}}"
+    - name: test
+      script: |
+        echo "{{ .actual }}" | grep "{{ .expected }}"
+
+steps:
+- task: test
+  arguments:
+    input: "FOO"
+    expected: "Double FOO will be: FOO_FOO"


### PR DESCRIPTION
Once you `name` a step within `steps` section of your `task`, next or following steps can refer to the output of the named step:

```
  steps:
  - name: res
    task: duplicate
    arguments:
      input: "{{.argument}}"
```

As the first step in the above example is named `res`, the subsequent step can refer to the output of the step by `res`, like:

```
  - script: |
      echo "Double {{.argument}} will be: {{.res}}"
```

Resolves #73