### PR TITLE
Remove restrictive Viper interface as not needed.

### DIFF
--- a/pkg/application.go
+++ b/pkg/application.go
@@ -41,7 +41,7 @@ type Application struct {
 
 	LastOutputs map[string]string
 
-	Viper Viper
+	Viper *viper.Viper
 
 	Log *logrus.Logger
 }

--- a/pkg/viper.go
+++ b/pkg/viper.go
@@ -1,8 +1,0 @@
-package variant
-
-import "github.com/spf13/viper"
-
-type Viper interface {
-	Get(key string) interface{}
-	Sub(key string) *viper.Viper
-}


### PR DESCRIPTION
I don't see any reason to introduce an additional and restrictive layer (interface) for the Viper usage, so I've removed it.