### PR TITLE
convert camelName to CAMEL_NAME with autoenv.

### DIFF
--- a/pkg/task_runner.go
+++ b/pkg/task_runner.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/huandu/xstrings"
 	log "github.com/sirupsen/logrus"
 
 	"fmt"
@@ -47,7 +48,7 @@ func (t TaskRunner) GetKey() Key {
 func (t TaskRunner) GenerateAutoenv() (map[string]string, error) {
 	replacer := strings.NewReplacer("-", "_", ".", "_")
 	toEnvName := func(parName string) string {
-		return strings.ToUpper(replacer.Replace(parName))
+		return strings.ToUpper(replacer.Replace(xstrings.ToKebabCase(parName)))
 	}
 	return t.GenerateAutoenvRecursively("", t.Values, toEnvName)
 }


### PR DESCRIPTION
I changed the parameter name to Camel Case with this change.
https://github.com/mumoshu/variant/commit/01bb4e1c8787d98d13bf0d4fed7fd3dcec32b1b8

```
parameters:
- name: awsAccessKeyId
- name: awsSecretAccessKey
- name: awsProfile
- name: awsDefaultRegion
```

However, the environment variable name generated by autoenv has become a string of UpperCase.

```
Generated autoenv: map[AWSACCESSKEYID: AWSDEFAULTREGION: AWSPROFILE: AWSSECRETACCESSKEY: CMD:./variantfile ENV:default]
```

I think I should be `AWS_ACCESS_KEY_ID` instead of `AWSACCESSKEYID`.

