### PR TITLE
fixes parameter s3Bucket to be the argument --s3-bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ smoke15: build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./params-and-opts --logtostderr test > out && cat out | tee /dev/stderr | grep "param1=myparam1 param2=myparam2 opt1=myopt1" && echo smoke15 passed.
 
 smoke16: build
-	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./input-validation run param1x param2x --opt-str-1=optstr1 --opt-bool-1=true --opt-int-1=10 --logtostderr > out && cat out | tee /dev/stderr | grep "param1=param1x param2=param2x opt_str_1=optstr1 opt_str_2=opt2_default opt_bool_1=true opt_bool_2=true opt_int_1=10 opt_int_2=100" && echo smoke16 passed.
+	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./input-validation run param1x param2x --opt-str1=optstr1 --opt-bool1=true --opt-int1=10 --logtostderr > out && cat out | tee /dev/stderr | grep "param1=param1x param2=param2x opt_str_1=optstr1 opt_str_2=opt2_default opt_bool_1=true opt_bool_2=true opt_int_1=10 opt_int_2=100" && echo smoke16 passed.
 
 smoke17: build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./array-input test --logtostderr > out && cat out | tee /dev/stderr | ( grep "foo: foo/foo1.txt" out && grep "foo: foo/foo2.txt" && grep "bar: bar/bar1.txt" out && grep "bar: bar/bar2.txt" out) && echo smoke17 passed.

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ smoke24: build
 
 smoke25: build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && \
-	./defaults ok --bool-3=true --integer-3=3 | grep foo=FOO,empty1=,empty2=,task=task,bar=bar,baz=baz,bool1=false,bool2=true,bool3=true,integer1=0,integer2=1,integer3=3 && \
+	./defaults ok --bool3=true --integer3=3 | grep foo=FOO,empty1=,empty2=,task=task,bar=bar,baz=baz,bool1=false,bool2=true,bool3=true,integer1=0,integer2=1,integer3=3 && \
 	! ./defaults ng1 && ! ./defaults ng2 && ! ./defaults ng3 && echo smoke25 passed.
 
 smoke26: build

--- a/pkg/cobra.go
+++ b/pkg/cobra.go
@@ -2,12 +2,11 @@ package variant
 
 import (
 	"fmt"
-	"github.com/huandu/xstrings"
+	"github.com/mumoshu/variant/pkg/util/stringutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 type CobraAdapter struct {
@@ -103,7 +102,7 @@ func (p *CobraAdapter) GenerateAllFlags() {
 
 			log.Debugf("short=%s, full=%s, name=%s, selected=%s", input.ShortName(), input.FullName, input.Name, name)
 
-			flagName := strings.Replace(xstrings.ToKebabCase(name), ".", "-", -1)
+			flagName := stringutil.ToArgumentName(name)
 
 			var keyForConfigFromFlag string
 			if input.TaskKey.ShortString() == task.Name.ShortString() {

--- a/pkg/task_runner.go
+++ b/pkg/task_runner.go
@@ -1,10 +1,10 @@
 package variant
 
 import (
+	"github.com/mumoshu/variant/pkg/util/stringutil"
 	"os"
 	"strings"
 
-	"github.com/huandu/xstrings"
 	log "github.com/sirupsen/logrus"
 
 	"fmt"
@@ -46,11 +46,7 @@ func (t TaskRunner) GetKey() Key {
 }
 
 func (t TaskRunner) GenerateAutoenv() (map[string]string, error) {
-	replacer := strings.NewReplacer("-", "_", ".", "_")
-	toEnvName := func(parName string) string {
-		return strings.ToUpper(replacer.Replace(xstrings.ToKebabCase(parName)))
-	}
-	return t.GenerateAutoenvRecursively("", t.Values, toEnvName)
+	return t.GenerateAutoenvRecursively("", t.Values, stringutil.ToEnvironmentName)
 }
 
 func (t TaskRunner) GenerateAutoenvRecursively(path string, env map[string]interface{}, toEnvName func(string) string) (map[string]string, error) {

--- a/pkg/util/stringutil/stringutil.go
+++ b/pkg/util/stringutil/stringutil.go
@@ -1,0 +1,23 @@
+package stringutil
+
+import (
+	"github.com/huandu/xstrings"
+	"regexp"
+	"strings"
+)
+
+var (
+	regex            = regexp.MustCompile(`-([0-9]+)`)
+	argumentReplacer = strings.NewReplacer(".", "-")
+	envReplacer      = strings.NewReplacer("-", "_", ".", "_")
+)
+
+func ToArgumentName(name string) string {
+	n := strings.Trim(regex.ReplaceAllString(xstrings.ToKebabCase(name), "$1-"), "-")
+	return argumentReplacer.Replace(n)
+}
+
+func ToEnvironmentName(name string) string {
+	n := strings.Trim(regex.ReplaceAllString(xstrings.ToKebabCase(name), "$1-"), "-")
+	return strings.ToUpper(envReplacer.Replace(n))
+}

--- a/test/integration/autoenv_task_step
+++ b/test/integration/autoenv_task_step
@@ -12,5 +12,5 @@ tasks:
 
   exec:
     script: |
-      echo ${PARAM_1}
+      echo ${PARAM1}
 


### PR DESCRIPTION
`s3Bucket` parameter are converted to `--s-3bucket` for arguments and `S_3BUCKET` for environment variables.

```
#!/usr/bin/env variant
tasks:
  foo:
    parameters:
    - name: s3Bucket
      default: ""
    autoenv: true
    script: |
      echo {{ get "s3Bucket" }}
```

```
$ ./hoge foo --help
Usage:
  hoge foo [s3Bucket] [flags]

Flags:
  -h, --help               help for foo
      --s-3bucket string   s3Bucket
```

```
Generated autoenv: map[CMD:./hoge ENV:cwk8s111-test S_3BUCKET:]
````

I think that it is natural that the argument is converted to `--s3-bucket` and the environment variable is converted to `S3_BUCKET`.