### PR TITLE
fix: regression in loading params from non-default config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ dist/$(VERSION):
 install:
 	go build -ldflags "-X 'github.com/mumoshu/variant/pkg/cli/version.VERSION=$(VERSION)'" -o ~/bin/variant .
 
+install-as-var:
+	go build -ldflags "-X 'github.com/mumoshu/variant/pkg/cli/version.VERSION=$(VERSION)'" -o ~/bin/var .
 
 release: dist/$(VERSION)
 	ghr -u $(GITHUB_USER) -r $(GITHUB_REPO) -c master --prerelease v$(VERSION) dist/$(VERSION)
@@ -180,8 +182,11 @@ smoke32: build
 smoke33: build
 	cd $(IT_DIR) && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && PARAM1="OK" ./autoenv_bind test --logtostderr | grep OK && echo smoke33 passed.
 
+smoke34: build
+	cd $(IT_DIR)/param-val-from-specific-config && export PATH=$(shell pwd)/dist/$(VERSION):$$PATH && ./mycmd test -c myconfig.yaml --logtostderr | grep foo=FOO,bar=BAR && echo smoke34 passed.
+
 smoke-tests:
 	make smoke{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27}
 
 smoke-ci:
-	bash -c 'make smoke{1..18} smoke{23,24,25,26,27,28,29,30,31,32,33}'
+	bash -c 'make smoke{1..18} smoke{23,24,25,26,27,28,29,30,31,32,33,34}'

--- a/pkg/application.go
+++ b/pkg/application.go
@@ -120,8 +120,7 @@ func (p *Application) loadContextConfigs() {
 	}
 }
 
-func (p *Application) loadConfig(configName string) error {
-	fileName := fmt.Sprintf("%s.yaml", configName)
+func (p *Application) loadConfigFile(fileName string) error {
 	msg := fmt.Sprintf("loading config file %s...", fileName)
 	if fileutil.Exists(fileName) {
 		p.Viper.SetConfigFile(fileName)
@@ -136,6 +135,10 @@ func (p *Application) loadConfig(configName string) error {
 		p.Log.Debugf("%s missing", msg)
 	}
 	return nil
+}
+
+func (p *Application) loadConfig(configName string) error {
+	return p.loadConfigFile(fmt.Sprintf("%s.yaml", configName))
 }
 
 func (p *Application) UpdateLoggingConfiguration() error {

--- a/pkg/variant.go
+++ b/pkg/variant.go
@@ -179,7 +179,7 @@ func Init(commandPath string, rootTaskConfig *TaskDef, opts ...Opts) (*CobraApp,
 
 	// Load a config from the provided flag (could be loaded through Viper as well)
 	if p.ConfigFile != "" {
-		p.loadConfig(p.ConfigFile)
+		p.loadConfigFile(p.ConfigFile)
 	}
 
 	// Load contexts configuration

--- a/test/integration/param-val-from-specific-config/mycmd
+++ b/test/integration/param-val-from-specific-config/mycmd
@@ -1,0 +1,8 @@
+#!/usr/bin/env var
+tasks:
+  test:
+    parameters:
+    - name: foo
+    - name: bar
+    script: |
+      echo foo={{.foo}},bar={{.bar}}

--- a/test/integration/param-val-from-specific-config/myconfig.yaml
+++ b/test/integration/param-val-from-specific-config/myconfig.yaml
@@ -1,0 +1,2 @@
+foo: FOO
+bar: BAR


### PR DESCRIPTION
Running `mycmd -c config.yaml` doesn't seem to correctly load settings from the file, while the default config `mycmd.yaml` is loaded without any problem.